### PR TITLE
Add missing video processing dependencies

### DIFF
--- a/llava/utils.py
+++ b/llava/utils.py
@@ -20,7 +20,7 @@ try:
     import av
     from decord import VideoReader, cpu
 except ImportError:
-    print("Please install pyav to use video processing functions.")
+    print("Please install 'av' and 'decord' packages to use video processing functions.")
 
 def process_video_with_decord(video_file, data_args):
     vr = VideoReader(video_file, ctx=cpu(0), num_threads=1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 huggingface_hub
 pillow
 transformers
+av
+decord


### PR DESCRIPTION
Added Missing Video Processing Dependencies
llava/utils.py attempts to import both av (PyAV) and decord for video processing functionality, but these dependencies are not listed in requirements.txt. This leads to runtime errors and potentially confusing error messages for users, as the error only mentions PyAV even though both packages are required.

Changes Made
Added required video processing dependencies to requirements.txt:
av
decord
Updated the error message in llava/utils.py to be more accurate and helpful, now indicating both required packages instead of just PyAV.

Benefits
Users will automatically get all required dependencies when installing via pip install -r requirements.txt
Clearer error message that accurately indicates both required packages
Prevents confusion and streamlines the setup process

Test
Verified that both packages install correctly
Confirmed that video processing functionality works with both dependencies installed
Tested that the new error message appears correctly when dependencies are missing