### PR TITLE
Fix import for fresh transformers

### DIFF
--- a/llava/model/multimodal_resampler/qformer.py
+++ b/llava/model/multimodal_resampler/qformer.py
@@ -38,6 +38,8 @@ from transformers.modeling_outputs import (
 )
 from transformers.modeling_utils import (
     PreTrainedModel,
+)
+from transformers.pytorch_utils import (
     apply_chunking_to_forward,
     find_pruneable_heads_and_indices,
     prune_linear_layer,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 huggingface_hub
 pillow
-transformers
+transformers>=4.57.0


### PR DESCRIPTION
For google:

```
Failed to import llava_llama from llava.language_model.llava_llama. Error: cannot import name 'apply_chunking_to_forward' from 'transformers.modeling_utils' (f:\@comfy311\Lib\site-packages\transformers\modeling_utils.py)
ImportError: cannot import name 'LlavaLlamaForCausalLM' from 'F:\\ComfyUI_v0_x_5\\custom_nodes\\ComfyUI-LLaVA-OneVision.llava.model' (F:\ComfyUI_v0.5\custom_nodes\ComfyUI-LLaVA-OneVision\llava\model\__init__.py)

Cannot import F:\ComfyUI_v0.5\custom_nodes\ComfyUI-LLaVA-OneVision module for custom nodes: cannot import name 'LlavaLlamaForCausalLM' from 'F:\\ComfyUI_v0_x_5\\custom_nodes\\ComfyUI-LLaVA-OneVision.llava.model' (F:\ComfyUI_v0.5\custom_nodes\ComfyUI-LLaVA-OneVision\llava\model\__init__.py)
```